### PR TITLE
Add aiohttp REST server and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@ This project provides a non-root overlay cheat framework for Mobile Legends: Ban
 ## Vector Modules
 Placeholder modules `vector001`–`vector163` implement individual anti-cheat checks. Each exposes a `run()` function returning a status string.
 
+## REST Server
+`pi/rest_server.py` provides a small aiohttp service exposing a `/health` endpoint. The server runs until the provided stop event is triggered.
+
 ## Development
 Run sanitizers and tests before committing:
 

--- a/pi/rest_server.py
+++ b/pi/rest_server.py
@@ -1,0 +1,41 @@
+import asyncio
+from aiohttp import web
+from typing import Optional
+
+
+async def handle_health(request: web.Request) -> web.Response:
+    """Return server health status."""
+    return web.json_response({"status": "ok"})
+
+
+async def start_server(
+    host: str = "127.0.0.1",
+    port: int = 8080,
+    stop_event: Optional[asyncio.Event] = None,
+) -> asyncio.Event:
+    """Start an aiohttp server and block until ``stop_event`` is set."""
+    app = web.Application()
+    app.router.add_get("/health", handle_health)
+
+    runner = web.AppRunner(app)
+    await runner.setup()
+    site = web.TCPSite(runner, host, port)
+    await site.start()
+
+    # Wait until cancelled
+    if stop_event is None:
+        stop_event = asyncio.Event()
+    try:
+        await stop_event.wait()
+    finally:
+        await runner.cleanup()
+    return stop_event
+
+
+def run(host: str = "127.0.0.1", port: int = 8080) -> None:
+    """Run the server until interrupted."""
+    stop_event = asyncio.Event()
+    try:
+        asyncio.run(start_server(host, port, stop_event))
+    except KeyboardInterrupt:
+        stop_event.set()

--- a/tests/test_rest_server.py
+++ b/tests/test_rest_server.py
@@ -1,0 +1,30 @@
+import asyncio
+
+import aiohttp
+import pytest
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+
+from pi import rest_server
+
+
+@pytest.mark.asyncio
+async def test_health_endpoint_responds():
+    stop_event = asyncio.Event()
+    server_task = asyncio.create_task(
+        rest_server.start_server('127.0.0.1', 8081, stop_event)
+    )
+
+    # Wait briefly for the server to start
+    await asyncio.sleep(0.1)
+    async with aiohttp.ClientSession() as session:
+        async with session.get('http://127.0.0.1:8081/health') as resp:
+            assert resp.status == 200
+            data = await resp.json()
+            assert data == {'status': 'ok'}
+
+    stop_event.set()
+    await server_task
+


### PR DESCRIPTION
## Summary
- implement `pi/rest_server.py` with async server start and run functions
- document REST server in README
- add `test_rest_server` to verify health endpoint

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851162cef748333b4b43553110dff5b