### PR TITLE
Fix workflow to use GH_PAT and sanitize

### DIFF
--- a/.github/workflows/unicode_sanitizer.yml
+++ b/.github/workflows/unicode_sanitizer.yml
@@ -6,7 +6,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+          token: ${{ secrets.GH_PAT }}
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -14,11 +17,13 @@ jobs:
       - name: Install dependencies
         run: |
           pip install -r requirements.txt
-      - name: Run sanitizers
+      - name: Run sanitizers and tests
         run: |
-          python ci/remove_cjk.py $(git ls-files '*.py') || {
-            echo 'CJK characters removed. Please review.'; exit 1; }
-          python ci/remove_bidi.py $(git ls-files '*.py') || {
-            echo 'BIDI characters removed. Please review.'; exit 1; }
-      - name: Run tests
-        run: pytest -q
+          find . -name '*.py' -exec python3 ci/remove_cjk.py {} +
+          find . -name '*.py' -exec python3 ci/remove_bidi.py {} +
+          pytest --maxfail=1 --disable-warnings -q
+      - name: Push changes to protected branch
+        uses: ad-m/github-push-action@v0.8.0
+        with:
+          github_token: ${{ secrets.GH_PAT }}
+          branch: ${{ github.head_ref }}

--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ python ci/remove_bidi.py $(git ls-files '*.py')
 pytest -q
 ```
 
+## CI with Personal Access Token
+GitHub Actions uses a `GH_PAT` secret with a personal access token to push
+changes back to protected branches. Generate a token with **repo** scope from the
+GitHub settings page and add it as a repository secret. The workflow checks out
+code with `persist-credentials: false` to ensure pushes use the PAT.
+
 ## Contributing (Mitmachen)
 * Sanitize all Python files with `ci/remove_cjk.py` and `ci/remove_bidi.py`.
 * Execute `pytest -q` before committing to ensure the test suite passes.


### PR DESCRIPTION
## Summary
- use `actions/checkout@v4` with `persist-credentials: false` and `GH_PAT`
- sanitize before running tests and push back with PAT
- document PAT requirement in README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68512421428c83338c6d503c0493e00a