### PR TITLE
Fix overlay-app reference

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@ Non-root Mobile Legends: Bang Bang overlay cheats for S23 Ultra streamed to Rasp
 
 ## Directory Structure
 - `pi/` – Raspberry Pi support and helpers
-- `overlay-app/` – Android overlay app modules
+- `overlay-app/` – Android overlay app modules (placeholder)
 - `termux/` – Termux scripts and utilities
 - `ci/` – CI configurations and pipelines
 - `tests/` – Unit/integration tests

--- a/overlay-app/README.md
+++ b/overlay-app/README.md
@@ -1,0 +1,3 @@
+# Overlay App
+
+This directory will contain Android overlay app modules.


### PR DESCRIPTION
## Summary
- create `overlay-app/` with placeholder README
- adjust AGENTS guidance to note placeholder directory

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68520d955b8883338a6d0a8e8d3caed7