### PR TITLE
Fix ASCII guard command in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,9 @@ jobs:
 
     - name: ASCII guard
       run: |
-        grep -R -nP '[^\x00-\x7F]' --include='*.{py,sh,json,yaml,yml}' \
+        grep -R -nP '[^\x00-\x7F]' \
+          --include='*.py' --include='*.sh' \
+          --include='*.json' --include='*.yaml' --include='*.yml' \
           --exclude-dir='.git' . \
           && { echo 'non-ASCII in code'; exit 1; } \
           || echo 'ASCII clean'


### PR DESCRIPTION
## Summary
- separate include patterns for grep in `ci.yml`
- maintain exit error when non-ASCII characters detected

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685516ecb4ec8333b38a7e410711f66d