### PR TITLE
Add overlay loadtest vector and cleanup test

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,7 @@ This project’s automation and vector logic are managed by modular agents.
 | EntropyAgent           | vectors/vector005_entropy.py   | Adds entropy, session random  | Overlay state           | New entropy    | OverlayManager|
 | AntiBanAgent           | vectors/vector010_antiban_overlay.py | Hide overlay/screens, log clean | System events         | Clean state    |               |
 | TapBotAgent            | vectors/vector004_tapbot.py    | Simulates human tap entropy   | Tap command             | Touch event    | EntropyAgent  |
+| LoadTestAgent         | vector315_overlay_loadtest.py   | Overlay stress/load test cycles | cycles config        | Remaining handles | OverlayManager |
 
 ## Extension/Onboarding Instructions
 

--- a/docs/FUNCTION_INDEX.md
+++ b/docs/FUNCTION_INDEX.md
@@ -12,3 +12,4 @@ Every function in all vectors/scripts, indexed for Codex/LLM context and AI onbo
 - inject_module(): Loads cheats into memory
 - handle_screenshot(): Hides overlay on screenshot
 - relay_command(): Relays tapbot/overlay commands to device
+- overlay_loadtest(): Stress test overlay spawn and cleanup cycles

--- a/docs/WCTRA_context.md
+++ b/docs/WCTRA_context.md
@@ -10,6 +10,7 @@ Built for MLBB, S23 Ultra, Pi, and Termux. Features include overlay injection, E
 - Full vector module library, memory safe, Codex-ready
 - Device relays for Pi/Termux
 - CI/obfuscation, build/test automation
+- Overlay load testing for memory leaks
 - Full onboarding, changelog, registry, AI context
 
 ## Risks

--- a/tests/test_vector315_loadtest.py
+++ b/tests/test_vector315_loadtest.py
@@ -1,0 +1,12 @@
+from pathlib import Path
+import sys
+import os
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+import vector315_overlay_loadtest as v315
+
+
+def test_overlay_loadtest_cleanup():
+    os.makedirs('/test', exist_ok=True)
+    remaining = v315.run(cycles=2, per_cycle=3)
+    assert remaining == 0

--- a/vector315_overlay_loadtest.py
+++ b/vector315_overlay_loadtest.py
@@ -1,0 +1,28 @@
+"""vector315_overlay_loadtest.py - Overlay Load Test Vector
+Purpose: Rapidly spawn and remove overlay handles to stress test memory usage.
+"""
+import time
+
+
+def audit_log(event: str) -> None:
+    """Append event to the load test audit log."""
+    with open("/test/overlay_loadtest_audit.log", "a") as f:
+        f.write(f"[{time.strftime('%Y-%m-%d %H:%M:%S')}] {event}\n")
+
+
+def run(cycles: int = 5, per_cycle: int = 10) -> int:
+    """Run the overlay load test.
+
+    Creates and removes overlay handles per cycle.
+    Returns number of remaining handles (expected to be 0).
+    """
+    handles = []
+    for c in range(cycles):
+        for i in range(per_cycle):
+            handle = {"id": f"{c}-{i}"}
+            handles.append(handle)
+            audit_log(f"Spawned {handle}")
+        handles.clear()
+        audit_log(f"Cycle {c} cleaned")
+    return len(handles)
+


### PR DESCRIPTION
## Summary
- create `vector315_overlay_loadtest.py` for stress testing overlay spawn cycles
- add pytest `tests/test_vector315_loadtest.py`
- document new agent in `AGENTS.md`
- log new helper in `docs/FUNCTION_INDEX.md`
- extend WCTRA tasks with overlay load testing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857f36e6b948333ba7fff108f4bd7a0