### PR TITLE
Expand Akademie agents

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -1,0 +1,11 @@
+# AGENTS.md - Akademie Modular Systems
+
+This document lists the primary automation agents used in the project.
+
+| Agent                | Module File                  | Responsibility                               | Inputs        | Outputs       |
+|----------------------|------------------------------|----------------------------------------------|---------------|---------------|
+| MaphackAgent         | `vectors/vector001_maphack.py` | Reveal enemy positions and draw ESP boxes   | Frame stream  | Overlay rects |
+| OverlayManagerAgent  | `vectors/vector002_overlay.py` | Manage overlay visibility and frame updates | Frame stream  | Rendered UI   |
+| TapBotAgent          | `vectors/vector004_tapbot.py`  | Send randomized tap commands                | None          | Touch events  |
+| EntropyAgent         | `vectors/vector005_entropy.py` | Rotate random seeds for other modules       | None          | New entropy   |
+| AntiBanOverlayAgent  | `vectors/vector010_antiban_overlay.py` | Hide overlay on screenshot events         | Events        | Clean state   |

--- a/docs/FUNCTION_INDEX.md
+++ b/docs/FUNCTION_INDEX.md
@@ -13,3 +13,10 @@ Every function in all vectors/scripts, indexed for Codex/LLM context and AI onbo
 - handle_screenshot(): Hides overlay on screenshot
 - relay_command(): Relays tapbot/overlay commands to device
 - overlay_loadtest(): Stress test overlay spawn and cleanup cycles
+
+## Akademie Modules
+- `vector001_maphack.py` – `MaphackAgent.run(frames)` scans frames and draws ESP boxes.
+- `vector002_overlay.py` – `OverlayManagerAgent.run(frame_stream)` shows and updates overlays.
+- `vector004_tapbot.py` – `TapBotAgent.run(reps)` sends randomized tap events.
+- `vector005_entropy.py` – `EntropyAgent.run(cycles)` rotates random seeds for modules.
+- `vector010_antiban_overlay.py` – `AntiBanOverlayAgent.run(event_stream)` hides overlay on screenshots.

--- a/vector_manifest_starter.json
+++ b/vector_manifest_starter.json
@@ -11,6 +11,36 @@
       "type": "entropy",
       "hash": "PLACEHOLDER",
       "last_validated": "2025-06-24"
+    },
+    {
+      "name": "vector001_maphack.py",
+      "type": "overlay",
+      "hash": "PLACEHOLDER",
+      "last_validated": "2025-06-24"
+    },
+    {
+      "name": "vector002_overlay.py",
+      "type": "overlay",
+      "hash": "PLACEHOLDER",
+      "last_validated": "2025-06-24"
+    },
+    {
+      "name": "vector004_tapbot.py",
+      "type": "automation",
+      "hash": "PLACEHOLDER",
+      "last_validated": "2025-06-24"
+    },
+    {
+      "name": "vector005_entropy.py",
+      "type": "entropy",
+      "hash": "PLACEHOLDER",
+      "last_validated": "2025-06-24"
+    },
+    {
+      "name": "vector010_antiban_overlay.py",
+      "type": "anti-detect",
+      "hash": "PLACEHOLDER",
+      "last_validated": "2025-06-24"
     }
   ],
   "scripts": [

--- a/vectors/vector001_maphack.py
+++ b/vectors/vector001_maphack.py
@@ -1,9 +1,72 @@
+"""vector001_maphack.py - Basic map reveal agent.
+
+This module scans incoming frames for enemy locations and draws
+ESP boxes on the overlay. Audit logs are written to ``/test/vector001_maphack.log``.
+"""
+
+from __future__ import annotations
+
+import os
+import random
 import time
+from typing import Iterable, List, Tuple
 
-def run():
-    print("[Maphack] Overlaying map data...")
-    time.sleep(1)
-    print("[Maphack] Map reveal complete, audit hash: ab1c3d7.")
 
-if __name__ == "__main__":
+AUDIT_LOG = "/test/vector001_maphack.log"
+
+
+def audit_log(event: str) -> None:
+    """Append an audit event to the log file."""
+    os.makedirs(os.path.dirname(AUDIT_LOG), exist_ok=True)
+    with open(AUDIT_LOG, "a", encoding="utf-8") as f:
+        timestamp = time.strftime("%Y-%m-%d %H:%M:%S")
+        f.write(f"[{timestamp}] {event}\n")
+
+
+class DummyOverlayAPI:
+    """Placeholder overlay API used for testing."""
+
+    def draw_rect(self, x: int, y: int, w: int = 32, h: int = 32, *, color: str = "red", alpha: float = 0.6) -> None:
+        del x, y, w, h, color, alpha
+
+    def clear(self) -> None:
+        pass
+
+
+class MaphackAgent:
+    """Simple maphack overlay manager."""
+
+    def __init__(self, overlay_api: DummyOverlayAPI | None = None) -> None:
+        self.overlay_api = overlay_api or DummyOverlayAPI()
+
+    def scan(self, frame: object) -> List[Tuple[int, int]]:
+        """Fake enemy coordinate scan using random numbers."""
+        coords = [(random.randint(100, 1000), random.randint(200, 1500)) for _ in range(random.randint(1, 4))]
+        audit_log(f"detected enemies: {coords}")
+        return coords
+
+    def render(self, coords: Iterable[Tuple[int, int]]) -> None:
+        """Render rectangles at enemy coordinates."""
+        for x, y in coords:
+            self.overlay_api.draw_rect(x, y, color="red", alpha=0.55)
+            audit_log(f"draw {x},{y}")
+            time.sleep(random.uniform(0.05, 0.15))
+
+    def run(self, frames: Iterable[object] | None = None) -> None:
+        """Execute the maphack scanning loop."""
+        audit_log("start")
+        if frames is None:
+            frames = [None] * 3
+        for frame in frames:
+            self.render(self.scan(frame))
+            time.sleep(random.uniform(0.5, 1.0))
+        audit_log("stop")
+
+
+def run() -> None:
+    """Entry point used by tests."""
+    MaphackAgent().run()
+
+
+if __name__ == "__main__":  # pragma: no cover
     run()

--- a/vectors/vector002_overlay.py
+++ b/vectors/vector002_overlay.py
@@ -1,9 +1,69 @@
+"""vector002_overlay.py - Overlay manager agent.
+
+Manages showing and hiding the ESP overlay and records basic frame
+render events for auditing. Audit logs are written to ``/test/vector002_overlay.log``.
+"""
+
+from __future__ import annotations
+
+import os
 import time
+from typing import Iterable
 
-def run():
-    print("[Overlay] Floating overlay active. Rendering ESP...")
-    time.sleep(1)
-    print("[Overlay] Overlay draw cycle complete.")
 
-if __name__ == "__main__":
+AUDIT_LOG = "/test/vector002_overlay.log"
+
+
+def audit_log(event: str) -> None:
+    os.makedirs(os.path.dirname(AUDIT_LOG), exist_ok=True)
+    with open(AUDIT_LOG, "a", encoding="utf-8") as f:
+        f.write(f"[{time.strftime('%Y-%m-%d %H:%M:%S')}] {event}\n")
+
+
+class DummyOverlayAPI:
+    def show(self) -> None: pass
+    def hide(self) -> None: pass
+    def render_frame(self, frame: object) -> None: pass
+
+
+class OverlayManagerAgent:
+    """Control overlay visibility and frame rendering."""
+
+    def __init__(self, overlay_api: DummyOverlayAPI | None = None) -> None:
+        self.overlay_api = overlay_api or DummyOverlayAPI()
+        self.visible = False
+
+    def show_overlay(self) -> None:
+        self.overlay_api.show()
+        self.visible = True
+        audit_log("overlay shown")
+
+    def hide_overlay(self) -> None:
+        self.overlay_api.hide()
+        self.visible = False
+        audit_log("overlay hidden")
+
+    def update(self, frame: object) -> None:
+        self.overlay_api.render_frame(frame)
+        audit_log("frame rendered")
+
+    def run(self, frame_stream: Iterable[object] | None = None) -> None:
+        audit_log("manager start")
+        if frame_stream is None:
+            frame_stream = [None] * 5
+        self.show_overlay()
+        try:
+            for frame in frame_stream:
+                self.update(frame)
+                time.sleep(0.1)
+        finally:
+            self.hide_overlay()
+            audit_log("manager stop")
+
+
+def run() -> None:
+    OverlayManagerAgent().run()
+
+
+if __name__ == "__main__":  # pragma: no cover
     run()

--- a/vectors/vector004_tapbot.py
+++ b/vectors/vector004_tapbot.py
@@ -1,9 +1,57 @@
-import random, time
+"""vector004_tapbot.py - Tapbot entropy agent.
 
-def run():
-    print("[Tapbot] Humanized tap injected.")
-    time.sleep(random.uniform(0.1, 0.3))
-    print("[Tapbot] Tap entropy: OK.")
+Generates human-like tap events with random delays. Audit logs
+are stored in ``/test/vector004_tapbot.log``.
+"""
 
-if __name__ == "__main__":
+from __future__ import annotations
+
+import os
+import random
+import time
+from typing import Iterable, Tuple
+
+AUDIT_LOG = "/test/vector004_tapbot.log"
+
+
+def audit_log(event: str) -> None:
+    os.makedirs(os.path.dirname(AUDIT_LOG), exist_ok=True)
+    with open(AUDIT_LOG, "a", encoding="utf-8") as f:
+        f.write(f"[{time.strftime('%Y-%m-%d %H:%M:%S')}] {event}\n")
+
+
+class DummyTapAPI:
+    def tap(self, x: int, y: int, duration: float = 0.1) -> None:
+        del x, y, duration
+
+
+class TapBotAgent:
+    def __init__(self, tap_api: DummyTapAPI | None = None) -> None:
+        self.tap_api = tap_api or DummyTapAPI()
+
+    def random_point(self) -> Tuple[int, int]:
+        x = random.randint(300, 900)
+        y = random.randint(400, 1500)
+        return x, y
+
+    def send_tap(self) -> None:
+        x, y = self.random_point()
+        duration = random.uniform(0.08, 0.25)
+        self.tap_api.tap(x, y, duration)
+        audit_log(f"tap {x},{y} {duration:.2f}s")
+        time.sleep(duration)
+
+    def run(self, reps: int = 5) -> None:
+        audit_log("tapbot start")
+        for _ in range(reps):
+            self.send_tap()
+            time.sleep(random.uniform(0.1, 0.3))
+        audit_log("tapbot stop")
+
+
+def run() -> None:
+    TapBotAgent().run()
+
+
+if __name__ == "__main__":  # pragma: no cover
     run()

--- a/vectors/vector005_entropy.py
+++ b/vectors/vector005_entropy.py
@@ -1,11 +1,43 @@
-import time, os
+"""vector005_entropy.py - Overlay entropy rotation agent.
 
-def run():
-    print("[Entropy] Entropy rotation started.")
-    for _ in range(3):
-        time.sleep(0.3)
-        print("[Entropy] Randomizing overlay session seed.")
-    print("[Entropy] Entropy injection OK.")
+Randomizes internal seeds and timings for other modules. Logs are
+written to ``/test/vector005_entropy.log``.
+"""
 
-if __name__ == "__main__":
+from __future__ import annotations
+
+import os
+import random
+import time
+from typing import Iterable
+
+AUDIT_LOG = "/test/vector005_entropy.log"
+
+
+def audit_log(event: str) -> None:
+    os.makedirs(os.path.dirname(AUDIT_LOG), exist_ok=True)
+    with open(AUDIT_LOG, "a", encoding="utf-8") as f:
+        f.write(f"[{time.strftime('%Y-%m-%d %H:%M:%S')}] {event}\n")
+
+
+class EntropyAgent:
+    def rotate_entropy(self) -> int:
+        seed = random.getrandbits(32)
+        random.seed(seed)
+        audit_log(f"seed {seed}")
+        time.sleep(0.1)
+        return seed
+
+    def run(self, cycles: int = 3) -> None:
+        audit_log("entropy start")
+        for _ in range(cycles):
+            self.rotate_entropy()
+        audit_log("entropy end")
+
+
+def run() -> None:
+    EntropyAgent().run()
+
+
+if __name__ == "__main__":  # pragma: no cover
     run()

--- a/vectors/vector010_antiban_overlay.py
+++ b/vectors/vector010_antiban_overlay.py
@@ -1,13 +1,62 @@
+"""vector010_antiban_overlay.py - Screenshot anti-detection agent.
+
+Hides the overlay whenever a screenshot event is detected and performs
+self-clean after use. Audit logs are written to ``/test/vector010_antiban.log``.
+"""
+
+from __future__ import annotations
+
+import os
 import time
+from typing import Iterable
 
-def self_clean():
-    print("[AntiBanOverlay] Self-clean complete.")
+AUDIT_LOG = "/test/vector010_antiban.log"
 
-def run():
-    print("[AntiBanOverlay] Hiding overlay for screenshot detection.")
-    time.sleep(2)
-    print("[AntiBanOverlay] Overlay restored.")
-    self_clean()
 
-if __name__ == "__main__":
+def audit_log(event: str) -> None:
+    os.makedirs(os.path.dirname(AUDIT_LOG), exist_ok=True)
+    with open(AUDIT_LOG, "a", encoding="utf-8") as f:
+        f.write(f"[{time.strftime('%Y-%m-%d %H:%M:%S')}] {event}\n")
+
+
+class DummyOverlayAPI:
+    def hide(self) -> None: pass
+    def show(self) -> None: pass
+
+
+class AntiBanOverlayAgent:
+    def __init__(self, overlay_api: DummyOverlayAPI | None = None) -> None:
+        self.overlay_api = overlay_api or DummyOverlayAPI()
+
+    def self_clean(self) -> None:
+        audit_log("self clean")
+        # additional cleanup could be added here
+
+    def handle_event(self, event: str) -> None:
+        if event == "screenshot":
+            self.overlay_api.hide()
+            audit_log("overlay hidden")
+            time.sleep(1)
+            self.overlay_api.show()
+            audit_log("overlay restored")
+
+    def run(self, event_stream: Iterable[str] | None = None) -> None:
+        audit_log("antiban start")
+        if event_stream is None:
+            event_stream = ["screenshot"]
+        for event in event_stream:
+            self.handle_event(event)
+        self.self_clean()
+        audit_log("antiban end")
+
+
+def self_clean() -> None:
+    AntiBanOverlayAgent().self_clean()
+
+
+def run() -> None:
+    AntiBanOverlayAgent().run()
+
+
+if __name__ == "__main__":  # pragma: no cover
     run()


### PR DESCRIPTION
## Summary
- flesh out primary Akademie agents with logging and simple logic
- add agent table in docs
- index new modules in FUNCTION_INDEX
- list agents in manifest

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68589a3a518c8333953ef9828c191cb1