### PR TITLE
Potential fix for code scanning alert no. 20: Full server-side request forgery

### DIFF
--- a/mlbb_integration_generator.py
+++ b/mlbb_integration_generator.py
@@ -33,7 +33,7 @@ if DISCORD_WEBHOOK_URL:
     
     # Validate DISCORD_WEBHOOK_URL
     parsed_url = urlparse(DISCORD_WEBHOOK_URL)
-    if parsed_url.scheme in ["http", "https"] and parsed_url.netloc.endswith("discord.com"):
+    if parsed_url.scheme in ["http", "https"] and parsed_url.netloc and (parsed_url.netloc == "discord.com" or parsed_url.netloc.endswith(".discord.com")):
         requests.post(DISCORD_WEBHOOK_URL, json={
             'content': f"Codex MLBB overlay updated at {datetime.utcnow().isoformat()} UTC"
         })

--- a/mlbb_integration_generator.py
+++ b/mlbb_integration_generator.py
@@ -29,8 +29,15 @@ subprocess.run([
 
 if DISCORD_WEBHOOK_URL:
     import requests
-    requests.post(DISCORD_WEBHOOK_URL, json={
-        'content': f"Codex MLBB overlay updated at {datetime.utcnow().isoformat()} UTC"
-    })
+    from urllib.parse import urlparse
+    
+    # Validate DISCORD_WEBHOOK_URL
+    parsed_url = urlparse(DISCORD_WEBHOOK_URL)
+    if parsed_url.scheme in ["http", "https"] and parsed_url.netloc.endswith("discord.com"):
+        requests.post(DISCORD_WEBHOOK_URL, json={
+            'content': f"Codex MLBB overlay updated at {datetime.utcnow().isoformat()} UTC"
+        })
+    else:
+        print("Invalid DISCORD_WEBHOOK_URL. Ensure it points to a trusted domain.")
 
 print('Done. Review changes and commit.')


### PR DESCRIPTION
Potential fix for [https://github.com/Streep69/mlbb-overlay-protection/security/code-scanning/20](https://github.com/Streep69/mlbb-overlay-protection/security/code-scanning/20)

To fix the issue, we need to validate the `DISCORD_WEBHOOK_URL` before using it in the `requests.post` call. A secure approach is to maintain a whitelist of allowed URLs or domains and ensure that the provided URL matches one of the entries in the whitelist. Alternatively, we can parse the URL and verify that it points to a trusted domain.

The fix involves:
1. Adding a validation step for `DISCORD_WEBHOOK_URL` to ensure it matches a trusted domain or URL pattern.
2. Rejecting or logging an error if the URL is invalid or untrusted.
3. Updating the code to include the validation logic before making the HTTP request.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
