### PR TITLE
Add SessionObfuscator vector

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,7 @@ This project’s automation and vector logic are managed by modular agents.
 | AntiBanAgent           | vectors/vector010_antiban_overlay.py | Hide overlay/screens, log clean | System events         | Clean state    |               |
 | TapBotAgent            | vectors/vector004_tapbot.py    | Simulates human tap entropy   | Tap command             | Touch event    | EntropyAgent  |
 | LoadTestAgent         | vector315_overlay_loadtest.py   | Overlay stress/load test cycles | cycles config        | Remaining handles | OverlayManager |
+| SessionObfuscatorAgent| vector316_session_obfuscator.py | Randomize session IDs and overlay names | None | New session ID | OverlayManager |
 
 ## Extension/Onboarding Instructions
 

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -9,3 +9,5 @@ This document lists the primary automation agents used in the project.
 | TapBotAgent          | `vectors/vector004_tapbot.py`  | Send randomized tap commands                | None          | Touch events  |
 | EntropyAgent         | `vectors/vector005_entropy.py` | Rotate random seeds for other modules       | None          | New entropy   |
 | AntiBanOverlayAgent  | `vectors/vector010_antiban_overlay.py` | Hide overlay on screenshot events         | Events        | Clean state   |
+| LoadTestAgent        | `vector315_overlay_loadtest.py`        | Overlay stress/load cycles                | cycles config | Remaining handles |
+| SessionObfuscatorAgent | `vector316_session_obfuscator.py` | Randomize session IDs and overlay names | None | New session ID |

--- a/docs/FUNCTION_INDEX.md
+++ b/docs/FUNCTION_INDEX.md
@@ -20,3 +20,5 @@ Every function in all vectors/scripts, indexed for Codex/LLM context and AI onbo
 - `vector004_tapbot.py` – `TapBotAgent.run(reps)` sends randomized tap events.
 - `vector005_entropy.py` – `EntropyAgent.run(cycles)` rotates random seeds for modules.
 - `vector010_antiban_overlay.py` – `AntiBanOverlayAgent.run(event_stream)` hides overlay on screenshots.
+- `vector315_overlay_loadtest.py` – `LoadTestAgent.run(cycles, per_cycle)` stress tests overlay spawning.
+- `vector316_session_obfuscator.py` – `SessionObfuscatorAgent.run()` rotates overlay handles and session IDs.

--- a/tests/test_vector316_session_obfuscator.py
+++ b/tests/test_vector316_session_obfuscator.py
@@ -1,0 +1,10 @@
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+import vector316_session_obfuscator as v316
+
+
+def test_session_obfuscator_run():
+    session_id = v316.SessionObfuscatorVector().run()
+    assert isinstance(session_id, str) and len(session_id) == 16

--- a/vector316_session_obfuscator.py
+++ b/vector316_session_obfuscator.py
@@ -1,0 +1,54 @@
+"""vector316_session_obfuscator.py - Session Obfuscator Vector
+Purpose: randomize session identifiers and overlay handles to reduce detection.
+Anti-detection: rotates session IDs, renames overlay resources, logs actions.
+"""
+import os
+import random
+import string
+import time
+
+
+def audit_log(event: str) -> None:
+    """Append event to the session obfuscator audit log."""
+    os.makedirs("/test", exist_ok=True)
+    with open("/test/session_obfuscator_audit.log", "a", encoding="utf-8") as f:
+        f.write(f"[{time.strftime('%Y-%m-%d %H:%M:%S')}] {event}\n")
+
+
+def _random_string(length: int = 8) -> str:
+    """Return a random alphanumeric string."""
+    return ''.join(random.choices(string.ascii_letters + string.digits, k=length))
+
+
+class SessionObfuscatorVector:
+    """Obfuscate session IDs and overlay names."""
+
+    def __init__(self, overlay_api=None) -> None:
+        self.overlay_api = overlay_api
+
+    def rotate_handle(self) -> str:
+        """Generate and assign a new overlay handle name."""
+        handle = _random_string(12)
+        if self.overlay_api:
+            self.overlay_api.rename_handle(handle)
+        audit_log(f"Overlay handle rotated to {handle}")
+        return handle
+
+    def rotate_session_id(self) -> str:
+        """Generate a new session ID."""
+        session_id = _random_string(16)
+        audit_log(f"Session ID set to {session_id}")
+        return session_id
+
+    def run(self) -> str:
+        """Run the session obfuscator and return the new session ID."""
+        audit_log("SessionObfuscator started")
+        handle = self.rotate_handle()
+        session_id = self.rotate_session_id()
+        audit_log(f"Obfuscation complete: handle={handle}, session={session_id}")
+        return session_id
+
+
+if __name__ == "__main__":
+    obf = SessionObfuscatorVector()
+    obf.run()

--- a/vector_manifest_starter.json
+++ b/vector_manifest_starter.json
@@ -42,6 +42,12 @@
       "hash": "PLACEHOLDER",
       "last_validated": "2025-06-24"
     }
+    ,{
+      "name": "vector316_session_obfuscator.py",
+      "type": "anti-detect",
+      "hash": "PLACEHOLDER",
+      "last_validated": "2025-06-24"
+    }
   ],
   "scripts": [
     {


### PR DESCRIPTION
## Summary
- add `vector316_session_obfuscator.py` to randomize session IDs and overlay names
- document SessionObfuscatorAgent in AGENTS and FUNCTION_INDEX
- include vector in manifest
- add tests for session obfuscator

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858e9d4a5488333aeda69642f1662fe